### PR TITLE
Changed button view topBorderWidth to the hairlineWidth

### DIFF
--- a/src/stylesheets/customKeyboard.css.js
+++ b/src/stylesheets/customKeyboard.css.js
@@ -21,7 +21,7 @@ const styles = StyleSheet.create({
   buttonview:{
     width:                      SCREEN_WIDTH,
     padding:                    8,
-    borderTopWidth:             0.5,
+    borderTopWidth:             StyleSheet.hairlineWidth,
     flexDirection:              'row',
     justifyContent:             'space-between',
     borderTopColor:             'lightgrey',


### PR DESCRIPTION
This change addresses a render issue on iOS devices with high pixel density (iPhone 6+ & 7+).
The underlying issue is documented here https://github.com/facebook/react-native/issues/12401