### PR TITLE
[FIX] Deprecated View.propTypes.style

### DIFF
--- a/src/components/selectinput/SelectInput.android.js
+++ b/src/components/selectinput/SelectInput.android.js
@@ -9,7 +9,7 @@ import styles from './../../stylesheets/selectInputAndroid.css.js';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import { Picker, View } from 'react-native';
+import { Picker, View, ViewPropTypes } from 'react-native';
 
 class SelectInput extends AbstractSelectInput {
   constructor(props) {
@@ -56,7 +56,7 @@ SelectInput.propTypes = {
   labelStyle: PropTypes.oneOfType([Picker.propTypes.style, PropTypes.arrayOf(Picker.propTypes.style)]),
   mode:       PropTypes.oneOf(['dialog', 'dropdown']),
   options:    PropTypes.array,
-  style:      PropTypes.oneOfType([View.propTypes.style, PropTypes.arrayOf(View.propTypes.style)]),
+  style:      PropTypes.oneOfType([ViewPropTypes.style, PropTypes.arrayOf(ViewPropTypes.style)]),
   value:      PropTypes.any,
 };
 

--- a/src/components/selectinput/SelectInput.ios.js
+++ b/src/components/selectinput/SelectInput.ios.js
@@ -10,7 +10,7 @@ import styles from './../../stylesheets/selectInputIOS.css.js';
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Text, TouchableWithoutFeedback, View } from 'react-native';
+import { Text, TouchableWithoutFeedback, View, ViewPropTypes } from 'react-native';
 
 class SelectInput extends AbstractSelectInput {
   constructor(props) {
@@ -83,7 +83,7 @@ SelectInput.propTypes = {
   onSubmitEditing:         PropTypes.func,
   options:                 PropTypes.array,
   submitKeyText:           PropTypes.string,
-  style:                   PropTypes.oneOfType([View.propTypes.style, PropTypes.arrayOf(View.propTypes.style)]),
+  style:                   PropTypes.oneOfType([ViewPropTypes.style, PropTypes.arrayOf(ViewPropTypes.style)]),
   value:                   PropTypes.any,
 };
 


### PR DESCRIPTION
This fixes #10, addressing the deprecated View.propTypes.style in favor of ViewPropTypes.style.

 