### PR TITLE
[IOS] When press cancel btn will set current value back to picker state

### DIFF
--- a/src/components/PickerKeyboard.js
+++ b/src/components/PickerKeyboard.js
@@ -44,6 +44,11 @@ class PickerKeyboard extends Component {
   onCancelPress() {
     this.setVisible(false);
 
+    // When press cancel will set current value back to picker state
+    this.setState({
+      value: this.props.value
+    });
+
     let onCancel = this.props.onCancel;
     onCancel && onCancel();
   }


### PR DESCRIPTION
I tested on our app and found that when user press cancel button. Value don't set back to picker component so value in picker will stay on last value.

I will test on android later if I found same problem I will create another pull request but I don't think it really need because in Android implementation. You use pure picker in component.