### PR TITLE
[IOS] Move padding from CustomKeyboard to inside of KeyboardButton fo…

### DIFF
--- a/src/components/KeyboardButton.js
+++ b/src/components/KeyboardButton.js
@@ -26,7 +26,8 @@ class KeyboardButton extends Component {
             width: BUTTON_WIDTH,
             color: props.color,
             textAlign: props.textAlign,
-            fontSize: props.textSize || null
+            fontSize: props.textSize || null,
+            padding: 8
           }}
         >
           {props.text}

--- a/src/stylesheets/customKeyboard.css.js
+++ b/src/stylesheets/customKeyboard.css.js
@@ -20,7 +20,7 @@ const styles = StyleSheet.create({
   },
   buttonview:{
     width:                      SCREEN_WIDTH,
-    padding:                    8,
+    padding:                    0,
     borderTopWidth:             StyleSheet.hairlineWidth,
     flexDirection:              'row',
     justifyContent:             'space-between',


### PR DESCRIPTION
…r more touchable area.

I inspect area on done and cancel button on IOS picker and found button area is too small because padding on outside KeyboardButton and it make touchable area that will trigger cancel callback have bigger area.

This pull request make button have bigger so in smaller iphone screen user can press correctly.

You can testing touchable area by add random backgroundColor to style prop in each component. This is trick from our designer that guide me when I found problem in UI testing.