### PR TITLE
Changed the SelectInput ios labelStyle PropType 

### DIFF
--- a/src/components/selectinput/SelectInput.ios.js
+++ b/src/components/selectinput/SelectInput.ios.js
@@ -78,7 +78,7 @@ SelectInput.propTypes = {
   buttonsTextSize:         PropTypes.number,
   cancelKeyText:           PropTypes.string,
   keyboardBackgroundColor: PropTypes.string,
-  labelStyle:              PropTypes.object,
+  labelStyle:              PropTypes.oneOfType([ViewPropTypes.style, PropTypes.arrayOf(ViewPropTypes.style)]),
   onEndEditing:            PropTypes.func,
   onSubmitEditing:         PropTypes.func,
   options:                 PropTypes.array,


### PR DESCRIPTION
I am passing an array of style objects into the labelStyle in my app which works fine but gives an error as it doesn't match the expected PropType of labelStyle. I've updated the expected PropType to match to accept either a single style object or an array of style objects.

P.S Thanks for the component. Saved me a bunch of time.