### PR TITLE
Fixing Text styles not being recognized when using labelStyle

### DIFF
--- a/src/components/selectinput/SelectInput.ios.js
+++ b/src/components/selectinput/SelectInput.ios.js
@@ -78,7 +78,7 @@ SelectInput.propTypes = {
   buttonsTextSize:         PropTypes.number,
   cancelKeyText:           PropTypes.string,
   keyboardBackgroundColor: PropTypes.string,
-  labelStyle:              PropTypes.oneOfType([ViewPropTypes.style, PropTypes.arrayOf(ViewPropTypes.style)]),
+  labelStyle:              PropTypes.oneOfType([Text.style, PropTypes.arrayOf(Text.style)]),
   onEndEditing:            PropTypes.func,
   onSubmitEditing:         PropTypes.func,
   options:                 PropTypes.array,


### PR DESCRIPTION
According to docs, labelStyle receives RN's Text component styles but the code validates with ViewPropTypes. Changing to Text.styles fixes issue #17