### PR TITLE
Added placeholder label on top of value for iOS and Android 😉

### DIFF
--- a/src/components/selectinput/SelectInput.android.js
+++ b/src/components/selectinput/SelectInput.android.js
@@ -9,7 +9,7 @@ import styles from './../../stylesheets/selectInputAndroid.css.js';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import { Picker, View, ViewPropTypes } from 'react-native';
+import { Picker, Text, View, ViewPropTypes } from 'react-native';
 
 class SelectInput extends AbstractSelectInput {
   constructor(props) {
@@ -30,6 +30,7 @@ class SelectInput extends AbstractSelectInput {
 
     return (
       <View style={props.style}>
+        {props.placeholder ? <Text style={props.placeholderStyle || styles.defaultPlaceholderStyle}>{props.placeholder}</Text> : null}
         <Picker
           ref={(c) => {this.picker = c; }}
           mode={props.mode}
@@ -54,6 +55,8 @@ class SelectInput extends AbstractSelectInput {
 
 SelectInput.propTypes = {
   labelStyle: PropTypes.PropTypes.object,
+  placeholderStyle: PropTypes.PropTypes.object,
+  placehdoler: PropTypes.string,
   mode:       PropTypes.oneOf(['dialog', 'dropdown']),
   options:    PropTypes.array,
   style:      PropTypes.oneOfType([ViewPropTypes.style, PropTypes.arrayOf(ViewPropTypes.style)]),

--- a/src/components/selectinput/SelectInput.android.js
+++ b/src/components/selectinput/SelectInput.android.js
@@ -54,7 +54,7 @@ class SelectInput extends AbstractSelectInput {
 }
 
 SelectInput.propTypes = {
-  labelStyle: PropTypes.PropTypes.object,
+  labelStyle: PropTypes.oneOfType([PropTypes.PropTypes.object, PropTypes.number]),
   placeholderStyle: PropTypes.oneOfType([PropTypes.PropTypes.object, PropTypes.number]),
   placehdoler: PropTypes.string,
   mode:       PropTypes.oneOf(['dialog', 'dropdown']),

--- a/src/components/selectinput/SelectInput.android.js
+++ b/src/components/selectinput/SelectInput.android.js
@@ -55,7 +55,7 @@ class SelectInput extends AbstractSelectInput {
 
 SelectInput.propTypes = {
   labelStyle: PropTypes.PropTypes.object,
-  placeholderStyle: PropTypes.PropTypes.object,
+  placeholderStyle: PropTypes.oneOfType([PropTypes.PropTypes.object, PropTypes.number]),
   placehdoler: PropTypes.string,
   mode:       PropTypes.oneOf(['dialog', 'dropdown']),
   options:    PropTypes.array,

--- a/src/components/selectinput/SelectInput.ios.js
+++ b/src/components/selectinput/SelectInput.ios.js
@@ -44,6 +44,7 @@ class SelectInput extends AbstractSelectInput {
     return (
       <TouchableWithoutFeedback onPress={this.focus.bind(this)}>
         <View style={props.style}>
+          {props.placeholder ? <Text style={props.placeholderStyle || styles.defaultPlaceholderStyle}>{props.placeholder}</Text> : null}
           <Text
             style={props.labelStyle || styles.defaultlabelstyle}
             adjustFontSizeToFit={true}
@@ -82,7 +83,9 @@ SelectInput.propTypes = {
   buttonsTextSize:         PropTypes.number,
   cancelKeyText:           PropTypes.string,
   keyboardBackgroundColor: PropTypes.string,
-  labelStyle:              PropTypes.any , // FIXME: - use real proptype
+  labelStyle:              PropTypes.oneOfType([Text.style, PropTypes.arrayOf(Text.style)]),
+  placeholder:             PropTypes.string,
+  placeholderStyle:        PropTypes.oneOfType([Text.style, PropTypes.arrayOf(Text.style)]),
   onEndEditing:            PropTypes.func,
   onSubmitEditing:         PropTypes.func,
   options:                 PropTypes.array,

--- a/src/stylesheets/selectInputAndroid.css.js
+++ b/src/stylesheets/selectInputAndroid.css.js
@@ -11,6 +11,10 @@ const styles = StyleSheet.create({
     alignSelf:                  'center',
     fontSize:                   13,
   },
+  defaultPlaceholderStyle: {
+    paddingLeft:                8,
+    fontSize:                   12
+  }
 });
 
 export default styles;

--- a/src/stylesheets/selectInputIOS.css.js
+++ b/src/stylesheets/selectInputIOS.css.js
@@ -1,16 +1,19 @@
-import {
-  StyleSheet
-} from 'react-native';
+import { StyleSheet } from 'react-native';
 
 const styles = StyleSheet.create({
   defaultcontainerstyle: {
-    flexDirection:              'column',
-    justifyContent:             'center',
+    flexDirection: 'column',
+    justifyContent: 'center'
   },
   defaultlabelstyle: {
-    alignSelf:                  'center',
-    fontSize:                   13,
+    alignSelf: 'center',
+    fontSize: 13
   },
+  defaultPlaceholderStyle: {
+    alignSelf:                  'center',
+    marginBottom:               6, 
+    fontSize:                   12
+  }
 });
 
 export default styles;


### PR DESCRIPTION
Hi @markuswind,

I've implemented a new feature, now you can pass a placeholder property to the picker, and it'll render it above the selected value. This is useful if you need to style your select component like other inputs in your view. 
You can also pass a placeholderStyle property to customize the label!

Please let me know if you find it useful and if you can merge it :) 