### PR TITLE
Input label correctly concatenates based on same values.

### DIFF
--- a/src/components/AbstractSelectInput/AbstractSelectInput.js
+++ b/src/components/AbstractSelectInput/AbstractSelectInput.js
@@ -53,7 +53,7 @@ class AbstractSelectInput extends Component {
         if (option.value === value) {
           return option.label
         }
-      }) || ''
+      }).filter(v => v).join(', ') || ''
     )
   }
 }


### PR DESCRIPTION
If there are multiple options with the same value. The input field was just concatenating without a ','. This allows them to display correctly.