### PR TITLE
Fix iOS picker selection

### DIFF
--- a/src/components/CustomKeyboard/CustomKeyboard.js
+++ b/src/components/CustomKeyboard/CustomKeyboard.js
@@ -51,7 +51,7 @@ class CustomKeyboard extends Component {
           'landscape-right'
         ]}
       >
-        <TouchableWithoutFeedback onPress={this.onCancelPress.bind(this)}>
+        <TouchableWithoutFeedback>
           <View style={styles.container}>
             <View style={[styles.modal, { width }]}>
               <View style={[styles.buttonview, buttonsViewStyle, { width }]}>


### PR DESCRIPTION
This PR fixes the issue with using the Picker on iOS. The issue was/is with the `onCancelPress` being added on the TouchableWithoutFeedback wrapper component instead of just the cancelButton